### PR TITLE
Keep source file structure

### DIFF
--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -162,18 +162,17 @@ fileList.forEach((filepath) => {
     console.log(`Processing file ${filepath}`);
   }
 
-  const input = fs.readFileSync(filepath, 'utf8'),
-    outdir = path.join(outputDir, path.dirname(filepath)),
-    output = shuji(input, {
-      verbose: typeof opts.verbose === 'boolean' ?
-        opts.verbose :
-        false
-    });
+  const input = fs.readFileSync(filepath, 'utf8');
 
-  fs.ensureDirSync(outdir);
+  const output = shuji(input, {
+    verbose: typeof opts.verbose === 'boolean' ?
+      opts.verbose :
+      false
+  });
 
   Object.keys(output).forEach((item) => {
-    const outfile = path.join(outdir, item);
+    const outfile = path.resolve(outputDir, item);
+    fs.ensureDirSync(path.dirname(outfile));
 
     if (opts.verbose) {
       console.log(`Writing to file ${outfile}`);

--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -178,12 +178,7 @@ fileList.forEach((filepath) => {
       console.log(`Writing to file ${outfile}`);
     }
 
-    if (fs.existsSync(outfile)) {
-      console.error('File existed, skipping!');
-    }
-    else {
-      fs.writeFileSync(outfile, output[item], 'utf8');
-    }
+    fs.writeFileSync(outfile, output[item], 'utf8');
   });
 
 });

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (input, options) => {
 
     consumer.sources.forEach((source) => {
       const contents = consumer.sourceContentFor(source);
-      map[path.basename(source)] = contents;
+      map[source] = contents;
     });
   }
   else if (options.verbose) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shuji",
+  "name": "@jingsam/shuji",
   "version": "0.3.1",
   "description": "Reverse engineering JavaScript and CSS sources from sourcemaps",
   "main": "index.js",


### PR DESCRIPTION
Suppose we have two files:
```
/path/to/a.js
/other/path/to/a.js
```

In https://github.com/paazmaya/shuji/blob/master/index.js#L36
```
map[path.basename(source)] = contents;
```
Unfortunately, `/path/to/a.js` was overwrite.

This PR keep the file path and write to the directory which relative to the output_dir
