### PR TITLE
fix filename in windows can not include ?

### DIFF
--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -187,6 +187,7 @@ fileList.forEach(async (inputFilepath) => {
   }
 
   sourceFiles.forEach(([filename, content]) => {
+    filename = filename.replace(/(\?\S+)/, '');
     const outputFilepath = path.join(outdir, filename);
 
     if (opts.verbose) {

--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -187,7 +187,7 @@ fileList.forEach(async (inputFilepath) => {
   }
 
   sourceFiles.forEach(([filename, content]) => {
-    filename = filename.replace(/(\?\S+)/, '');
+    filename = filename.replace(/(\?\S+)/u, '');
     const outputFilepath = path.join(outdir, filename);
 
     if (opts.verbose) {


### PR DESCRIPTION
when I run shuji in windows, it failed with error:  Error: ENOENT: no such file or directory, open 'D:\xxx\flowChart.vue?f6f4'
I find that filename "flowChart.vue?f6f4". In windows filename can not include ?, so I change the code for removing "?f6f4", it work.