### PR TITLE
Preserve original folder structure. Fix output dir malformations. Fix process crash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ shuji - Reverse engineering JavaScript and CSS sources from sourcemaps
 Usage: shuji [options] <file|directory>
 
   -h, --help               Help and usage instructions
-  -V, --version            Version number
-  -v, --verbose            Verbose output, will print which file is currently being
-                           processed
   -o, --output-dir String  Output directory - default: .
+  -p, --preserve           Preserve sourcemap's original folder structure.
   -M, --match String       Regular expression for matching and filtering files -
                            default: \.map$
-  -r, --recursive          Recursively search matching files
+  -v, --verbose            Verbose output, will print which file is currently being
+                           processed
+  -V, --version            Version number
 
 Version 0.5.0
 ```
@@ -84,7 +84,6 @@ There should be no errors appearing after any JavaScript file changes.
 Please note that any features or changed will not be merged without working unit tests.
 
 ## Version history
-
 * `v0.6.0` (2019-05-27)
   - Removed the option for directory recursion, it is now always a recursive operation
   - Support for reading inline source maps, from JavaScript and CSS files

--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -45,6 +45,27 @@ const optsParser = optionator({
       description: 'Help and usage instructions'
     },
     {
+      option: 'match',
+      alias: 'M',
+      type: 'String',
+      default: '\\.map$',
+      description: 'Regular expression for matching and filtering files'
+    },
+    {
+      option: 'output-dir',
+      alias: 'o',
+      type: 'String',
+      default: '.',
+      description: 'Output directory'
+    },
+    {
+      option: 'preserve',
+      alias: 'p',
+      type: 'Boolean',
+      default: false,
+      description: 'Preserve sourcemap\'s original folder structure'
+    },
+    {
       option: 'version',
       alias: 'V',
       type: 'Boolean',
@@ -57,20 +78,6 @@ const optsParser = optionator({
       type: 'Boolean',
       default: false,
       description: 'Verbose output, will print which file is currently being processed'
-    },
-    {
-      option: 'output-dir',
-      alias: 'o',
-      type: 'String',
-      default: '.',
-      description: 'Output directory'
-    },
-    {
-      option: 'match',
-      alias: 'M',
-      type: 'String',
-      default: '\\.map$',
-      description: 'Regular expression for matching and filtering files'
     }
   ]
 });
@@ -143,5 +150,4 @@ fileList.forEach(async (inputFilepath) => {
   sourceFiles.forEach(([filename, content]) => {
     writeSources(filename, content, outputDir, opts);
   });
-
 });

--- a/bin/shuji.js
+++ b/bin/shuji.js
@@ -138,14 +138,10 @@ if (!fs.existsSync(outputDir)) {
 
 // Process then...
 fileList.forEach(async (inputFilepath) => {
-
-  const outdir = path.join(outputDir, path.dirname(inputFilepath));
-  fs.ensureDirSync(outdir);
-
   const sourceFiles = await shuji(inputFilepath, opts);
 
   sourceFiles.forEach(([filename, content]) => {
-    writeSources(filename, content, outdir, opts);
+    writeSources(filename, content, outputDir, opts);
   });
 
 });

--- a/lib/read-sources.js
+++ b/lib/read-sources.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const path = require('path');
-
 const sourceMap = require('source-map');
 
 /**
@@ -34,11 +32,7 @@ const readSources = async (input, options) => {
 
     consumer.sources.forEach((source) => {
       const contents = consumer.sourceContentFor(source);
-
-      console.log('source', source);
-      console.log('path.basename(source)', path.basename(source));
-
-      map[path.basename(source)] = contents;
+      map[source] = contents;
     });
   }
   else if (options.verbose) {

--- a/lib/write-sources.js
+++ b/lib/write-sources.js
@@ -18,12 +18,13 @@ const path = require('path'),
 const AFTER_QUESTION = /(\?\S+)/gu;
 
 const writeSources = (filename, content, outdir, options) => {
+  filename = options.preserve ? filename : path.basename(filename);
   filename = filename.replace(AFTER_QUESTION, '');
 
   const outputFilepath = path.join(outdir, filename);
 
-  //const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
-  //const outputFilepath = path.resolve(outputDir, safeSuffix);
+//  const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
+//  const safeOutputFilepath = path.resolve(outputFilepath, safeSuffix);
 
   if (options.verbose) {
     console.log(`Writing to file "${outputFilepath}"`);
@@ -38,8 +39,8 @@ const writeSources = (filename, content, outdir, options) => {
     try {
       fs.writeFileSync(outputFilepath, content, 'utf8');
     }
-    catch (e) {
-      console.log(`Error while trying to write file "${outputFilepath}"`, e);
+    catch (error) {
+      console.log(`Error while trying to write file "${outputFilepath}", skipping...`, error);
     }
   }
 };

--- a/lib/write-sources.js
+++ b/lib/write-sources.js
@@ -14,17 +14,15 @@ const path = require('path'),
   fs = require('fs-extra');
 
 // https://security.stackexchange.com/a/123723
-//const SAFE_PATH = /^(\.\.[/\\])+/gu;
+const SAFE_PATH = /^(\.\.[/\\])+/gu;
 const AFTER_QUESTION = /(\?\S+)/gu;
 
 const writeSources = (filename, content, outdir, options) => {
   filename = options.preserve ? filename : path.basename(filename);
   filename = filename.replace(AFTER_QUESTION, '');
 
-  const outputFilepath = path.join(outdir, filename);
-
-//  const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
-//  const safeOutputFilepath = path.resolve(outputFilepath, safeSuffix);
+  const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
+  const outputFilepath = path.resolve(outdir, safeSuffix);
 
   if (options.verbose) {
     console.log(`Writing to file "${outputFilepath}"`);

--- a/lib/write-sources.js
+++ b/lib/write-sources.js
@@ -35,7 +35,12 @@ const writeSources = (filename, content, outdir, options) => {
     console.error(`File "${outputFilepath}" already exists, skipping!`);
   }
   else {
-    fs.writeFileSync(outputFilepath, content, 'utf8');
+    try {
+      fs.writeFileSync(outputFilepath, content, 'utf8');
+    }
+    catch (e) {
+      console.log(`Error while trying to write file "${outputFilepath}"`, e);
+    }
   }
 };
 


### PR DESCRIPTION
This pull request addresses three different issues:
- Fixes a bug that crashed the process when a file failed to write.
- Fixes a bug that malformed the output dir when -o option is provided.
- Adds a feature to preserve the original folder structure of a source map.