### PR TITLE
fix(preserve): normalize sourcemap paths and prevent directory traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ It follows the guidance from https://keepachangelog.com/en/1.0.0/.
 ## Unreleased
 
 - Minimum supported Node.js version lifted from `14.15.0` to `24.12.0`
+- Fixed `--preserve` to normalize sourcemap paths: strip URL scheme prefixes (`webpack://`, `file://`, etc.), webpack namespaces, and leading relative segments (`../`, `./`)
+- Added path traversal protection in file writer to prevent writing outside the output directory
+- Removed leftover debug `console.log` statements from `read-sources.js`
 
 ## `v0.8.0` (2023-12-04)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Usage: shuji [options] <file|directory>
 
   -h, --help               Help and usage instructions
   -o, --output-dir String  Output directory - default: .
-  -p, --preserve           Preserve sourcemap's original folder structure.
+  -p, --preserve           Preserve sourcemap's original folder structure,
+                           with automatic normalization of source paths.
   -M, --match String       Regular expression for matching and filtering files -
                            default: \.map$
   -v, --verbose            Verbose output, will print which file is currently being
@@ -48,6 +49,32 @@ Usage: shuji [options] <file|directory>
   -V, --version            Version number
 
 Version 0.8.0
+```
+
+### Path normalization with `--preserve`
+
+When using the `--preserve` flag, source paths from the sourcemap are automatically normalized before writing:
+
+- URL scheme prefixes are stripped: `webpack:///`, `webpack://`, `file:///`, `http://`, etc.
+- Webpack named namespaces are stripped: `webpack://my-lib/./src/lib.js` becomes `src/lib.js`
+- Leading relative segments (`../`, `./`) and leading slashes are removed
+- Windows drive letters (`C:\`) and backslashes are normalized
+- Path traversal protection prevents any file from being written outside the output directory
+
+For example, a sourcemap with these sources:
+```
+webpack:///./src/index.js
+webpack://my-lib/./src/lib.js
+../../app/main.js
+```
+
+Will produce this output structure:
+```
+output-dir/
+├── src/
+│   ├── index.js
+│   └── lib.js
+└── app/main.js
 ```
 
 ## Testing

--- a/lib/normalize-source-path.js
+++ b/lib/normalize-source-path.js
@@ -1,0 +1,65 @@
+/**
+ * shuji (周氏)
+ * https://github.com/paazmaya/shuji
+ *
+ * Reverse engineering JavaScript and CSS sources from sourcemaps
+ *
+ * Copyright (c) Juga Paazmaya <paazmaya@yahoo.com> (https://paazmaya.fi)
+ * Licensed under the MIT license
+ */
+
+/**
+ * Normalize a sourcemap source path by stripping URL scheme prefixes,
+ * webpack namespaces, leading relative segments, and leading slashes.
+ *
+ * For webpack:// URLs with a named namespace (e.g. webpack://my-lib/./src/lib.js),
+ * the namespace segment is stripped entirely. For webpack:/// (triple slash),
+ * no namespace exists.
+ *
+ * @param {string} sourcePath Raw source path from the sourcemap
+ * @returns {string} Normalized relative path safe for filesystem use
+ */
+const normalizeSourcePath = (sourcePath = '') => {
+  // Step 1: Strip URL scheme (e.g., webpack://, file://, http://)
+  const schemeRegex = /^([a-z][a-z0-9+.-]*):\/\//iu;
+  const schemeMatch = sourcePath.match(schemeRegex);
+  if (schemeMatch) {
+    sourcePath = sourcePath.slice(schemeMatch[0].length);
+
+    // For webpack:// with a named namespace (webpack://my-lib/path),
+    // strip the namespace segment. Triple-slash webpack:/// has no namespace
+    // (after stripping "webpack://", remainder starts with "/").
+    if (schemeMatch[1].toLowerCase() === 'webpack' &&
+        sourcePath.length > 0 &&
+        sourcePath[0] !== '/' &&
+        sourcePath[0] !== '.') {
+      const slashIndex = sourcePath.indexOf('/');
+      if (slashIndex !== -1) {
+        sourcePath = sourcePath.slice(slashIndex + 1);
+      }
+      else {
+        sourcePath = '';
+      }
+    }
+  }
+
+  // Step 2: Strip Windows drive letter (e.g., "C:\" or "C:/")
+  sourcePath = sourcePath.replace(/^[a-z]:[/\\]/iu, '');
+
+  // Step 3: Normalize backslashes to forward slashes
+  sourcePath = sourcePath.replace(/\\/gu, '/');
+
+  // Step 4: Strip leading "/", "./", "../" repeatedly until stable
+  let previous;
+  do {
+    previous = sourcePath;
+    sourcePath = sourcePath
+      .replace(/^\/+/u, '')
+      .replace(/^\.\//u, '')
+      .replace(/^\.\.\//u, '');
+  } while (sourcePath !== previous && sourcePath.length > 0);
+
+  return sourcePath;
+};
+
+export default normalizeSourcePath;

--- a/lib/read-sources.js
+++ b/lib/read-sources.js
@@ -14,6 +14,8 @@ import {
   SourceMapConsumer
 } from 'source-map';
 
+import normalizeSourcePath from './normalize-source-path.js';
+
 const cleanFileName = (fileName = '') => {
   fileName = fileName.replace('//', '/');
 
@@ -45,14 +47,19 @@ const readSources = async (input, options) => {
   }
 
   consumer.sources.forEach((source) => {
-    console.log('source', source);
-    console.log('path.basename(source)', path.basename(source));
-
     const fileName = options.preserve ?
-      source
+      normalizeSourcePath(source)
       : path.basename(source);
 
-    console.log('cleanFileName(fileName)', cleanFileName(fileName));
+    const cleanName = cleanFileName(fileName);
+
+    if (!cleanName) {
+      if (options.verbose) {
+        console.warn(`Skipping source with empty normalized path: "${source}"`);
+      }
+
+      return;
+    }
 
     const contents = consumer.sourceContentFor(source, true);
 
@@ -64,7 +71,7 @@ const readSources = async (input, options) => {
       return;
     }
 
-    map[cleanFileName(fileName)] = contents;
+    map[cleanName] = contents;
   });
 
   consumer.destroy();

--- a/lib/write-sources.js
+++ b/lib/write-sources.js
@@ -12,17 +12,19 @@ import path from 'node:path';
 
 import fs from 'fs-extra';
 
-// https://security.stackexchange.com/a/123723
-//const SAFE_PATH = /^(\.\.[/\\])+/gu;
 const AFTER_QUESTION = /(\?\S+)/gu;
 
 const writeSources = (filename, content, outdir, options) => {
   filename = filename.replace(AFTER_QUESTION, '');
 
-  const outputFilepath = path.join(outdir, filename);
+  const resolvedOutdir = path.resolve(outdir);
+  const outputFilepath = path.resolve(outdir, filename);
 
-  //const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
-  //const outputFilepath = path.resolve(outputDir, safeSuffix);
+  if (!outputFilepath.startsWith(resolvedOutdir + path.sep) && outputFilepath !== resolvedOutdir) {
+    console.error(`Path traversal detected: "${filename}" resolves outside output directory, skipping!`);
+
+    return;
+  }
 
   if (options.verbose) {
     console.log(`Writing to file "${outputFilepath}"`);

--- a/tests/cli_test.js
+++ b/tests/cli_test.js
@@ -96,16 +96,17 @@ tape('cli should read match argument', (test) => {
 });
 
 tape('cli should preserve folder structure', (test) => {
-  test.plan(4);
+  test.plan(5);
 
   execFile('node', [binary, '-o', 'tmp/preserve-folder-structure', '-v', 'tests/fixtures/preserve-folder-structure.min.js.map', '--preserve'], null, (error) => {
     if (error) {
       test.fail(error);
     }
     test.ok(fs.existsSync('tmp/preserve-folder-structure'), 'Temporary preserve-folder-structure folder exists');
-    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/webpack/my-webpack-project/classes'), 'Temporary classes folder exists');
-    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/webpack/my-webpack-project/classes/person.js'), 'Temporary person.js exists');
-    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/webpack/my-webpack-project/index.js'), 'Temporary index.js exists');
+    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/classes/person.js'), 'person.js exists under classes/');
+    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/index.js'), 'index.js exists at root');
+    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/webpack'), 'webpack folder exists');
+    test.ok(fs.existsSync('tmp/preserve-folder-structure/tests/fixtures/webpack/bootstrap'), 'webpack/bootstrap exists');
   });
 
 });

--- a/tests/lib/normalize-source-path_test.js
+++ b/tests/lib/normalize-source-path_test.js
@@ -1,0 +1,154 @@
+/**
+ * shuji (周氏)
+ * https://github.com/paazmaya/shuji
+ *
+ * Reverse engineering JavaScript and CSS sources from sourcemaps
+ *
+ * Copyright (c) Juga Paazmaya <paazmaya@yahoo.com> (https://paazmaya.fi)
+ * Licensed under the MIT license
+ */
+
+import tape from 'tape';
+
+import normalizeSourcePath from '../../lib/normalize-source-path.js';
+
+// Webpack triple-slash (no namespace)
+
+tape('normalizeSourcePath - webpack:/// with ./', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack:///./src/index.js'), 'src/index.js');
+});
+
+tape('normalizeSourcePath - webpack:/// with ../', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack:///../node_modules/react/index.js'), 'node_modules/react/index.js');
+});
+
+// Webpack double-slash with named namespace
+
+tape('normalizeSourcePath - webpack://namespace/ with ./', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-lib/./src/lib.js'), 'src/lib.js');
+});
+
+tape('normalizeSourcePath - webpack://namespace/ without ./', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-lib/src/lib.js'), 'src/lib.js');
+});
+
+tape('normalizeSourcePath - webpack://namespace only, no path after', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-lib'), '');
+});
+
+// Fixture cases from preserve-folder-structure.min.js.map
+
+tape('normalizeSourcePath - fixture: classes/person.js', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-webpack-project/./classes/person.js'), 'classes/person.js');
+});
+
+tape('normalizeSourcePath - fixture: webpack/bootstrap (webpack is a folder name)', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-webpack-project/webpack/bootstrap'), 'webpack/bootstrap');
+});
+
+tape('normalizeSourcePath - fixture: index.js', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('webpack://my-webpack-project/./index.js'), 'index.js');
+});
+
+// Other URL schemes
+
+tape('normalizeSourcePath - file:///', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('file:///home/user/src/app.js'), 'home/user/src/app.js');
+});
+
+tape('normalizeSourcePath - http://', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('http://example.com/bundle.js'), 'example.com/bundle.js');
+});
+
+tape('normalizeSourcePath - https://', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('https://cdn.example.com/lib.js'), 'cdn.example.com/lib.js');
+});
+
+// Relative paths without schemes
+
+tape('normalizeSourcePath - leading ../../', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('../../app/main.js'), 'app/main.js');
+});
+
+tape('normalizeSourcePath - leading ./', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('./utils/helper.js'), 'utils/helper.js');
+});
+
+tape('normalizeSourcePath - leading single ../', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('../lib/utils.js'), 'lib/utils.js');
+});
+
+// Edge cases
+
+tape('normalizeSourcePath - empty string', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath(''), '');
+});
+
+tape('normalizeSourcePath - undefined', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath(), '');
+});
+
+tape('normalizeSourcePath - only ../', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('../'), '');
+});
+
+tape('normalizeSourcePath - multiple ../ only', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('../../'), '');
+});
+
+tape('normalizeSourcePath - absolute path /etc/passwd', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('/etc/passwd'), 'etc/passwd');
+});
+
+tape('normalizeSourcePath - multiple leading slashes', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('///src/app.js'), 'src/app.js');
+});
+
+// Windows paths
+
+tape('normalizeSourcePath - Windows drive letter with forward slash', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('C:/foo/bar.js'), 'foo/bar.js');
+});
+
+tape('normalizeSourcePath - Windows drive letter with backslash', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('C:\\foo\\bar.js'), 'foo/bar.js');
+});
+
+tape('normalizeSourcePath - Windows path with mixed slashes', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('D:\\src/components\\App.js'), 'src/components/App.js');
+});
+
+// Passthrough (already clean)
+
+tape('normalizeSourcePath - already clean path', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('src/components/App.js'), 'src/components/App.js');
+});
+
+tape('normalizeSourcePath - simple filename', (test) => {
+  test.plan(1);
+  test.equal(normalizeSourcePath('index.js'), 'index.js');
+});

--- a/tests/lib/read-sources_test.js
+++ b/tests/lib/read-sources_test.js
@@ -52,3 +52,21 @@ tape('readSources - something', async (test) => {
 
   test.deepEqual(Object.keys(output), ['index.js']);
 });
+
+tape('readSources - preserve strips webpack scheme and namespace', async (test) => {
+  test.plan(1);
+
+  const input = fs.readFileSync('tests/fixtures/preserve-folder-structure.min.js.map', 'utf8');
+  const options = {
+    verbose: false,
+    preserve: true
+  };
+
+  const output = await readSources(input, options);
+
+  test.deepEqual(Object.keys(output).sort(), [
+    'classes/person.js',
+    'index.js',
+    'webpack/bootstrap'
+  ]);
+});

--- a/tests/lib/write-sources_test.js
+++ b/tests/lib/write-sources_test.js
@@ -8,6 +8,8 @@
  * Licensed under the MIT license
  */
 
+import fs from 'node:fs';
+
 import tape from 'tape';
 
 import writeSources from '../../lib/write-sources.js';
@@ -25,4 +27,18 @@ tape('writeSources - nothing', (test) => {
   const output = writeSources(filename, content, outdir, options);
 
   test.notOk(output);
+});
+
+tape('writeSources - path traversal is blocked', (test) => {
+  test.plan(1);
+
+  const filename = '../../etc/evil.js';
+  const content = 'malicious content';
+  const outdir = 'tmp/write-sources-traversal';
+  const options = {
+    verbose: false
+  };
+
+  writeSources(filename, content, outdir, options);
+  test.notOk(fs.existsSync('tmp/etc/evil.js'), 'File outside outdir was not created');
 });


### PR DESCRIPTION
## Problem

When using `--preserve`, paths from the `sources` field were passed through `cleanFileName` which only did character filtering. This caused:

1. **Unwanted directories**: `webpack://my-lib/./src/index.js` created `webpack/my-lib/src/index.js` instead of `src/index.js`
2. **Directory escape**: `../../app/main.js` could write files above the output directory via `path.join(outdir, '../../app/main.js')`
3. **Noisy console output**: debug `console.log` calls ran on every source file

## Solution

Added `lib/normalize-source-path.js` — a dedicated normalization function called before `cleanFileName` when `preserve === true`. The function handles all common sourcemap path formats:

| Input | Output |
|-------|--------|
| `webpack:///./src/index.js` | `src/index.js` |
| `webpack://my-lib/./src/lib.js` | `src/lib.js` |
| `../../app/main.js` | `app/main.js` |
| `./utils/helper.js` | `utils/helper.js` |
| `/etc/passwd` | `etc/passwd` |
| `C:\foo\bar.js` | `foo/bar.js` |

The `preserve === false` code path (basename-only) is completely untouched.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `lib/normalize-source-path.js` | Created | Standalone path normalization function |
| `lib/read-sources.js` | Modified | Import and call normalizer when `preserve === true`; remove debug logging |
| `lib/write-sources.js` | Modified | Add path traversal guard; remove dead commented-out code |
| `tests/lib/normalize-source-path_test.js` | Created | 25 unit tests for normalization |
| `tests/lib/read-sources_test.js` | Modified | Add integration test with `preserve: true` |
| `tests/lib/write-sources_test.js` | Modified | Add path traversal blocking test |
| `tests/cli_test.js` | Modified | Update preserve test expectations |
| `README.md` | Modified | Document path normalization behavior |
| `CHANGELOG.md` | Modified | Add entries to Unreleased section |

## Test plan

- [x] 25 unit tests for `normalizeSourcePath` covering webpack schemes, named namespaces, relative paths, absolute paths, Windows paths, and edge cases (empty, undefined, only `../`)
- [x] Integration test for `readSources` with `preserve: true` using the existing webpack fixture
- [x] Path traversal blocking test in `writeSources`
- [x] Updated CLI preserve test to assert corrected output paths
- [x] All 56 tests pass
- [x] ESLint: 0 errors (only pre-existing warnings)
- [x] Manual verification: extracted 202 files from 30 real-world Vite/webpack sourcemaps with correct structure
