### PR TITLE
harden: add path validation in shuji.js

### DIFF
--- a/lib/write-sources.js
+++ b/lib/write-sources.js
@@ -21,8 +21,13 @@ const writeSources = (filename, content, outdir, options) => {
 
   const outputFilepath = path.join(outdir, filename);
 
-  //const safeSuffix = path.normalize(filename).replace(SAFE_PATH, '');
-  //const outputFilepath = path.resolve(outputDir, safeSuffix);
+  // Prevent path traversal: ensure the resolved output stays within outdir
+  const resolvedOutdir = path.resolve(outdir);
+  const resolvedFilepath = path.resolve(outputFilepath);
+  if (!resolvedFilepath.startsWith(resolvedOutdir + path.sep) && resolvedFilepath !== resolvedOutdir) {
+    console.error(`Skipping unsafe path "${filename}"`);
+    return;
+  }
 
   if (options.verbose) {
     console.log(`Writing to file "${outputFilepath}"`);


### PR DESCRIPTION
## Summary
Harden input handling in `bin/shuji.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `bin/shuji.js:107` |
| **Assessment** | Defensive hardening |
| **CWE** | CWE-22 |

**Description**: The application constructs output directories and writes files based on user-supplied input file paths and filenames extracted from source map content. If a malicious source map contains path traversal sequences (e.g., '../../../etc/cron.d/backdoor') in its 'sources' field, the writeSources function may write files outside the intended output directory. The lib/write-sources.js file was not available for review, so full path sanitization cannot be confirmed.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `lib/write-sources.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented files from being written outside the designated output directory.
  * Unsafe output paths are now skipped and reported with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->